### PR TITLE
feat(blog): add AI/LLM SMART goals engineering leadership posts

### DIFF
--- a/content/en/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
+++ b/content/en/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
@@ -1,0 +1,90 @@
+---
+title: "Stepping Forward: Setting SMART Goals for AI & LLM Literacy in Engineering Leadership"
+categories:
+  - Leadership
+  - AI
+  - Engineering Management
+date: 2024-07-07
+tags:
+  - ai-leadership
+  - llm
+  - engineering-management
+  - smart-goals
+  - team-efficiency
+  - performance-development
+description: "Why engineering managers should set SMART performance goals around GenAI and LLMs—and how to bring your team, your leadership, and your company along with you."
+subtitle: A practical guide to taking the first step in GenAI literacy as an engineering leader, defining measurable learning goals, and building organizational support for AI adoption.
+---
+
+# Stepping Forward: Setting SMART Goals for AI & LLM Literacy in Engineering Leadership
+
+Today is July 7, 2024. I’ve just made a decision I’ve been circling for a while: I’m no longer watching GenAI from the sidelines. I’m stepping forward.
+
+One of the first books I read when I moved into management was The Making of a Manager by Julie Zhuo. It stuck with me—not just for its advice, but for a single line that became a kind of motto: “Your job, as a manager, is to get better outcomes from a group of people working together.” Every time things feel too smooth, too comfortable, I return to that sentence. It reminds me that improvement doesn’t come from standing still. It comes from movement, from curiosity, and from leading the next step forward. Zhuo also writes, “The best outcomes come from inspiring people to action, not telling them what to do”—and that’s exactly what I’m trying to do here.
+
+As engineering managers, we’re not just responsible for delivery—we’re also responsible for keeping our teams relevant, efficient, and prepared. When a new technology like Large Language Models (LLMs) shows signs of becoming foundational, we can’t wait for top-down direction. We act.
+
+Everything I’m doing right now is still theoretical. I don’t yet know what we’ll learn, or whether it will work. But I have hope—and a plan. I want to explore how LLMs can make my day and my team’s day more efficient. And if any of it works, I want to share those learnings with others in my chapter, my tribe, and across teams.
+
+## Why AI & LLMs Matter for Engineering Managers
+
+The potential of GenAI in engineering is everywhere—boilerplate generation, documentation support, smarter incident triage, onboarding guides. But so far, most of it feels abstract. We hear success stories, but we don't yet live them day to day.
+
+Still, I believe it's on us to start trying. These models are not just novelties. They may become essential tools. As managers, it's our role to experiment, to understand what's possible, and to support our teams in doing the same.
+
+This isn't a one-off exploration. This is **a learning goal**—one that I'm actively shaping now.
+
+## Defining My SMART Performance Development Goal
+
+Here's the goal I just wrote and submitted as part of my performance development plan, using the SMART framework:
+
+**Specific**: I will gain practical knowledge of AI and LLM applications relevant to engineering management, focusing on identifying techniques that could realistically enhance our workflow.
+
+**Measurable**: I've outlined what I will do—seek CTO sponsorship to explore the space, complete two certifications, summarize five pieces of content, run three knowledge-sharing sessions, and pilot at least two AI-driven improvements.
+
+**Achievable**: I'm dedicating weekly time to this, using available online resources, and trying to solve real problems as experiments. No need to pause my responsibilities—just redirect part of my routine.
+
+**Relevant**: This is directly tied to efficiency, learning culture, and our long-term ability to adapt.
+
+**Time-Bound**: I aim to complete all of this by the end of Q4 2024.
+
+I'm not doing this to become an AI expert. I'm doing it to become a better manager for this era.
+
+## Inviting My Team to Join the Journey
+
+Alongside this, I've started encouraging my team to set similar learning goals. Nothing formal. Just an invitation to explore.
+
+Some are looking at prompting. Others are testing how AI helps in debugging or writing documentation. I don't have examples to point to yet—just a hunch that we'll get better at this if we try together.
+
+We're building space for experimentation into our cadence. Not KPIs. Not OKRs. Just learning.
+
+## Starting the Conversation with Leadership
+
+To get traction, I reached out to leadership. Not with a huge plan—just with a simple request that could open the door.
+
+### The Email I Sent
+
+> Subject: Budget Approval Request for ChatGPT Monthly Subscription
+>
+> Hi Tomas,
+>
+> Following up on our discussion during the last Tech Leaders Monthly Sync, where you challenged us to enhance our efficiency by incorporating and familiarizing ourselves with LLMs as productivity tools, I'm asking for budget approval for the ChatGPT monthly plan.
+>
+> Cost details:
+>
+> - Individual: $20/month
+> - Team: $25/month per person
+>
+> Please let me know if you need further info or would like me to connect with other teams already using it.
+
+This email helped frame the initiative in a practical, low-risk way. Now, we wait to see if others step in too.
+
+## From a Decision to a Capability
+
+Right now, I don't have results. I don't have data. I have a decision, a plan, and the first steps in motion.
+
+And that's enough.
+
+I believe the way we integrate AI into engineering teams won't come from a single directive. It will come from dozens of small, intentional experiments like this—run by managers who decide to go first.
+
+That's where I am today. Not with answers. But with a clear intention to find them—and bring others along.

--- a/content/pt/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
+++ b/content/pt/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
@@ -1,0 +1,90 @@
+---
+title: "Dando o Primeiro Passo: Estabelecendo Metas SMART para Aprendizado em IA e LLM na Liderança de Engenharia"
+categories:
+  - Leadership
+  - AI
+  - Engineering Management
+date: 2024-07-07
+tags:
+  - lideranca-tecnica
+  - llm
+  - gestao-de-engenharia
+  - metas-smart
+  - eficiencia-de-times
+  - desenvolvimento-profissional
+description: "Por que líderes de engenharia devem definir metas SMART sobre GenAI e LLMs — e como engajar seu time, sua liderança e sua organização nessa jornada."
+subtitle: Um guia prático para dar o primeiro passo na alfabetização em GenAI como líder de engenharia, definindo metas mensuráveis de aprendizado e construindo apoio organizacional para adoção de IA.
+---
+
+# Dando o Primeiro Passo: Estabelecendo Metas SMART para Aprendizado em IA e LLM na Liderança de Engenharia
+
+Hoje é 7 de julho de 2024. Acabei de tomar uma decisão que venho adiando há um tempo: não vou mais assistir à revolução do GenAI de longe. Estou dando o primeiro passo.
+
+Um dos primeiros livros que li quando entrei na gestão foi The Making of a Manager, da Julie Zhuo. Ele ficou comigo — não só pelos conselhos práticos, mas por uma frase que acabou virando um tipo de lema pessoal: “Seu trabalho, como gestor, é obter melhores resultados de um grupo de pessoas trabalhando juntas.” Sempre que tudo parece estar indo bem demais, de forma confortável demais, eu volto a essa frase. Ela me lembra que melhorar não vem da estagnação, mas do movimento, da curiosidade e da vontade de liderar o próximo passo. Zhuo também escreve: “Os melhores resultados vêm de inspirar pessoas à ação, não de dizer a elas o que fazer” — e é exatamente isso que estou tentando fazer aqui.
+
+Como gestores de engenharia, não somos apenas responsáveis por entregas — somos responsáveis por manter nossos times relevantes, eficientes e preparados. Quando uma nova tecnologia como os Modelos de Linguagem de Grande Escala (LLMs) começa a se tornar essencial, não podemos esperar por direções top-down. Precisamos agir.
+
+Tudo o que estou fazendo agora ainda é teórico. Não sei exatamente o que vamos aprender, ou se vai funcionar. Mas tenho esperança — e um plano. Quero explorar como os LLMs podem tornar meu dia e o dia do meu time mais eficiente. E, se algo der certo, quero compartilhar essas descobertas com outras equipes, capítulos e tribos.
+
+## Por que IA e LLMs Importam para Gestores de Engenharia
+
+O potencial do GenAI na engenharia está em todo lugar — geração de código repetitivo, ajuda com documentação, triagem de incidentes, onboarding mais eficiente. Mas, até agora, tudo parece um pouco abstrato. Ouvimos casos de sucesso, mas não vivemos isso no dia a dia.
+
+Mesmo assim, acredito que é nossa responsabilidade começar a tentar. Esses modelos não são só curiosidades. Eles podem se tornar ferramentas fundamentais. Como gestores, é nosso papel experimentar, entender o que é possível e apoiar nossas equipes no aprendizado.
+
+Isso não é uma exploração pontual. É **uma meta de aprendizado** — que estou moldando agora.
+
+## Definindo Minha Meta SMART de Desenvolvimento
+
+Aqui está a meta que acabei de escrever e submeter como parte do meu plano de desenvolvimento, usando o framework SMART:
+
+**Específica**: Vou adquirir conhecimento prático sobre aplicações de IA e LLMs relevantes para gestão de engenharia, com foco em identificar técnicas que possam ser aplicadas aos nossos fluxos de trabalho.
+
+**Mensurável**: Pretendo conseguir patrocínio do nosso CTO para explorar o tema, concluir dois cursos ou certificações, resumir cinco conteúdos relevantes, conduzir três sessões de compartilhamento e pilotar pelo menos duas melhorias com suporte de IA.
+
+**Atingível**: Estou dedicando tempo semanal para isso, usando materiais online e tentando resolver problemas reais do dia a dia como experimentos.
+
+**Relevante**: Essa meta está diretamente ligada à eficiência, à cultura de aprendizado e à nossa capacidade de adaptação futura.
+
+**Temporal**: Meu objetivo é concluir tudo até o final do quarto trimestre de 2024.
+
+Não estou fazendo isso para me tornar especialista em IA. Estou fazendo para ser um gestor melhor para este novo momento.
+
+## Convidando o Time para Acompanhar
+
+Junto com isso, comecei a encorajar meu time a escrever metas parecidas. Nada formal. Apenas um convite à curiosidade.
+
+Alguns estão explorando como melhorar prompts. Outros querem testar como IA ajuda em debugging ou documentação. Ainda não temos exemplos para mostrar — apenas uma intuição de que vamos melhorar se aprendermos juntos.
+
+Estamos criando espaço para experimentação dentro da nossa cadência. Sem KPIs. Sem OKRs. Apenas aprendizado.
+
+## Iniciando a Conversa com a Liderança
+
+Para ter apoio, entrei em contato com a liderança. Sem planos mirabolantes — apenas um pedido simples, com potencial de abrir caminho.
+
+### O E-mail que Enviei
+
+> Assunto: Solicitação de orçamento para plano mensal do ChatGPT
+>
+> Olá Tomas,
+>
+> Seguindo nossa conversa na última reunião de Tech Leaders, onde discutimos formas de aumentar a eficiência usando LLMs como ferramentas de produtividade, gostaria de solicitar aprovação de orçamento para o plano mensal do ChatGPT.
+>
+> Detalhes:
+>
+> - Individual: $20/mês
+> - Time: $25/mês por pessoa
+>
+> Fico à disposição se precisar de mais informações ou se quiser que eu conecte com outras equipes que já estejam utilizando.
+
+Esse email ajudou a apresentar a iniciativa como algo prático e de baixo risco. Agora é esperar para ver quem mais topa começar.
+
+## De Uma Decisão Para Uma Capacidade
+
+Neste momento, ainda não tenho resultados. Não tenho dados. Tenho uma decisão, um plano e os primeiros passos em andamento.
+
+E isso já é suficiente.
+
+Acredito que a integração da IA aos times de engenharia não virá de uma única diretriz. Ela virá de dezenas de pequenos experimentos conscientes como esse — liderados por gestores que decidiram começar primeiro.
+
+É aí que estou hoje. Sem respostas prontas. Mas com a intenção clara de buscá-las — e levar outros comigo.


### PR DESCRIPTION
Technical details:
- Added bilingual Hugo posts for 2024-07-07 with identical filenames for i18n support
- English version: content/en/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
- Portuguese version: content/pt/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
- Enhanced content with Julie Zhuo's "The Making of a Manager" reference and philosophy
- Proper Hugo frontmatter with categories (Leadership, AI, Engineering Management)
- Comprehensive tags for discoverability and SEO optimization
- Hugo testing verified: both posts accessible and listed correctly on respective language indexes

Content focus:
This article addresses the critical need for engineering managers to proactively develop AI/LLM literacy through structured SMART goals. The post provides a practical framework for setting measurable learning objectives, engaging teams in AI exploration, and securing organizational support for GenAI adoption.

Why this matters:
Engineering managers need concrete guidance on approaching the AI revolution strategically rather than reactively. This content fills a gap by offering actionable steps, real email templates, and a personal case study of implementing AI learning goals within existing performance development frameworks.

Hugo integration complete with verified multilingual linking and proper URL generation.