### PR TITLE
feat(blog): add prompting engineering MASTER technique posts with user story examples

### DIFF
--- a/content/en/posts/2024-07-28-prompt-engineering-master-technique.md
+++ b/content/en/posts/2024-07-28-prompt-engineering-master-technique.md
@@ -1,0 +1,115 @@
+---
+title: "Eighteen Days Later: Prompt Engineering & the MASTER Technique"
+categories:
+  - AI
+  - Productivity
+  - Engineering Management
+date: 2024-07-28
+tags:
+  - prompt-engineering
+  - ai-literacy
+  - master-technique
+  - genai
+  - productivity
+  - llm
+description: "A deep dive into structured prompt engineering using the MASTER technique - moving from asking questions to designing conversations with AI."
+subtitle: "Time flies when you're learning something cool - discovering how prompt engineering is design thinking, not magic, through the MASTER framework."
+---
+
+# Eighteen Days Later: Prompt Engineering & the MASTER Technique
+
+## Time flies when you're learning something cool
+
+It's been 18 days since I started this journey, and I have to say—time _really_ flies when you're learning something that feels both powerful and limitless.
+
+The more I explore, the more impressed I am by the sheer volume and quality of available content—whether you're a beginner, a developer, or a team lead. Resources come in all forms: books, blog posts, courses, and tons of brilliant YouTube creators. And the best part? They approach the topic with depth at every level.
+
+I've been reading Ethan Mollick's _Co-Intelligence_, a book that doesn't just tell you how AI works—it shows you how to work _with_ it. It's filled with practical ideas, critical reflections, and calls to action for knowledge workers.
+
+For videos, I started with **Jeff Su**, who makes GenAI productivity simple and approachable. Then moved to **IBM Technology** for a systems-level understanding of LLMs, before getting deeper into tool usage with **Dave Ebbelaar** and **Thu Vu**, who cover prompts, agents, and model internals with clarity and substance.
+
+## What I've learned: Prompting isn't magic—it's design
+
+The biggest eye-opener? **Prompt engineering is not just about wording—it's about design thinking.** It's about structure, iteration, and intent. And that's where the **MASTER technique** has really clicked for me.
+
+Let's break it down.
+
+## The MASTER Technique
+
+MASTER is a prompting framework that helps you make the most of your interaction with AI:
+
+| Letter | Meaning                 | Why It Matters                         |
+| ------ | ----------------------- | -------------------------------------- |
+| M      | **Markdown**            | Structure your request clearly         |
+| A      | **Act (Assign a Role)** | Gives the AI context and tone          |
+| S      | **Specific**            | Reduces ambiguity, increases relevance |
+| T      | **Threads**             | Keeps prompts focused and organized    |
+| E      | **Examples**            | Shows the AI what good looks like      |
+| R      | **Regenerate & Refine** | Reminds us AI is iterative, not final  |
+
+## Why MASTER works
+
+AI isn't a deterministic engine—it's a probability machine. Without structure, it makes assumptions that often don't match your goals. With **MASTER**, you shift the prompting from "asking a question" to "designing a conversation."
+
+Let's say I want AI to help me create a user story:
+
+```
+## Role:
+You are a senior product manager with expertise in agile development and user story writing.
+
+## Task:
+Write a user story for adding a notification system to our project management tool.
+
+## Context:
+- User: Development team members
+- Goal: Stay updated on task assignments and status changes
+- Format: Standard "As a... I want... So that..." structure
+- Include acceptance criteria
+
+## Example:
+"As a development team member, I want to receive real-time notifications when tasks are assigned to me or when their status changes, so that I can respond quickly and stay aligned with project priorities.
+
+Acceptance Criteria:
+- Notifications appear within 5 seconds of the triggering event
+- Users can customize notification preferences (email, in-app, Slack)
+- Notifications include task title, project name, and direct link to the task"
+```
+
+The difference from a plain "Write me a user story for notifications"? Night and day.
+
+## R is for Regenerate—and Reflect
+
+Even with MASTER, **your first output won't be your best**. That's where the **R** comes in. Regenerating isn't just retrying—it's reflecting.
+
+Ask yourself:
+
+- Did the tone match my audience?
+- Were the examples too generic?
+- Did I give enough context?
+- Should I add constraints or expectations?
+
+It's a design loop: prompt → review → refine.
+
+## Connecting the dots
+
+When I link this technique to the things I'm reading and watching, I notice a pattern: **every expert treats AI not as an oracle, but as a collaborator.**
+
+That's the vibe of _Co-Intelligence_. It's not about letting AI drive—it's about making it part of your team.
+
+Jeff Su teaches you to automate without abdicating. IBM Tech explains the "why" behind the output. Dave Ebbelaar and Thu Vu show you how to combine reasoning, chaining, and tools like agents to _go further_—but always with intent.
+
+## Takeaway for managers, devs, and teams
+
+If you're just starting in GenAI, don't worry about getting every prompt right. Focus on **clarity, structure, and iteration**.
+
+Try MASTER for your next:
+
+- Jira story description
+- Performance review draft
+- Strategic document
+- Data analysis prompt
+- Email response
+
+And don't forget: prompting is a skill. It gets better the more you do it—and it gets _deeper_ when you start treating AI not like a tool, but like a co-worker.
+
+More soon.

--- a/content/pt/posts/2024-07-28-prompt-engineering-master-technique.md
+++ b/content/pt/posts/2024-07-28-prompt-engineering-master-technique.md
@@ -1,0 +1,115 @@
+---
+title: "Dezoito Dias Depois: Engenharia de Prompts e a Técnica MASTER"
+categories:
+  - AI
+  - Productivity
+  - Engineering Management
+date: 2024-07-28
+tags:
+  - engenharia-prompts
+  - alfabetizacao-ia
+  - tecnica-master
+  - genai
+  - produtividade
+  - llm
+description: "Um mergulho profundo na engenharia estruturada de prompts usando a técnica MASTER - passando de fazer perguntas para desenhar conversas com IA."
+subtitle: "O tempo voa quando você está aprendendo algo incrível - descobrindo como engenharia de prompts é design thinking, não mágica, através do framework MASTER."
+---
+
+# Dezoito Dias Depois: Engenharia de Prompts e a Técnica MASTER
+
+## O tempo voa quando você está aprendendo algo incrível
+
+Já se passaram 18 dias desde que comecei essa jornada, e tenho que dizer—o tempo _realmente_ voa quando você está aprendendo algo tão poderoso e cheio de possibilidades.
+
+Quanto mais eu exploro, mais fico impressionado com a quantidade e a qualidade de conteúdo disponível—para iniciantes, desenvolvedores e líderes de equipe. Os recursos vêm de todos os lados: livros, blogs, cursos e vários criadores brilhantes no YouTube. E o melhor? Com profundidade em todos os níveis.
+
+Tenho lido _Co-Intelligence_, do Ethan Mollick, um livro que não só explica como a IA funciona—mas como você pode trabalhar _com_ ela. Cheio de ideias práticas, reflexões críticas e incentivos para quem vive do conhecimento.
+
+Nos vídeos, comecei com o **Jeff Su**, que torna o uso da IA simples e prático. Depois mergulhei nos vídeos da **IBM Technology**, que explicam os sistemas por trás dos LLMs. E para uso mais avançado, recomendo **Dave Ebbelaar** e **Thu Vu**, que explicam prompts, agentes e raciocínio com clareza e profundidade.
+
+## O que aprendi: Engenharia de Prompt não é mágica—é design
+
+A maior virada de chave foi entender que **engenharia de prompt não é só escolher palavras—é pensar como designer.** É sobre estrutura, intenção e iteração. E foi aí que a técnica **MASTER** fez todo o sentido.
+
+Vamos destrinchar.
+
+## A Técnica MASTER
+
+A técnica MASTER é uma abordagem estruturada para usar IA de forma mais eficiente:
+
+| Letra | Significado                    | Por que é importante                      |
+| ----- | ------------------------------ | ----------------------------------------- |
+| M     | **Markdown**                   | Estrutura o pedido com clareza            |
+| A     | **Atue (Atribua um papel)**    | Dá contexto e tom à resposta              |
+| S     | **Seja específico**            | Reduz ambiguidade e melhora a resposta    |
+| T     | **Threads (Foco no contexto)** | Evita confusão em tópicos mistos          |
+| E     | **Exemplos**                   | Mostra o que você espera                  |
+| R     | **Refinar e Regenerar**        | Lembra que IA é iterativa, não definitiva |
+
+## Por que MASTER funciona
+
+IA não é um motor determinístico—é uma máquina de probabilidade. Sem estrutura, ela assume demais. Com o MASTER, você transforma o prompt de "pergunta" para "conversa desenhada".
+
+Por exemplo, ao pedir ajuda para criar uma user story:
+
+```
+## Papel:
+Você é um product manager sênior com expertise em desenvolvimento ágil e escrita de user stories.
+
+## Tarefa:
+Escreva uma user story para adicionar um sistema de notificações à nossa ferramenta de gestão de projetos.
+
+## Contexto:
+- Usuário: Membros do time de desenvolvimento
+- Objetivo: Manter-se atualizado sobre atribuições de tarefas e mudanças de status
+- Formato: Estrutura padrão "Como... eu quero... para que..."
+- Incluir critérios de aceitação
+
+## Exemplo:
+"Como membro do time de desenvolvimento, eu quero receber notificações em tempo real quando tarefas são atribuídas a mim ou quando seu status muda, para que eu possa responder rapidamente e me manter alinhado com as prioridades do projeto.
+
+Critérios de Aceitação:
+- Notificações aparecem em até 5 segundos após o evento
+- Usuários podem personalizar preferências (email, in-app, Slack)
+- Notificações incluem título da tarefa, nome do projeto e link direto"
+```
+
+Muito melhor do que só dizer "escreva uma user story para notificações".
+
+## R é de Refinar—e Refletir
+
+Mesmo com o MASTER, **o primeiro resultado raramente será o ideal**. É aí que entra o **R**. Regenerar não é só tentar de novo—é refletir.
+
+Pergunte:
+
+- O tom está certo para o público?
+- O exemplo está genérico demais?
+- Dei contexto suficiente?
+- Preciso adicionar restrições?
+
+É um loop de design: prompt → revisão → ajuste.
+
+## Conectando os pontos
+
+Ao aplicar essa técnica no conteúdo que consumo, vejo um padrão: **todo expert trata IA como um colaborador, não um oráculo.**
+
+Essa é a essência de _Co-Intelligence_. Não é IA no comando—é IA como parte da equipe.
+
+Jeff Su ensina a automatizar com consciência. IBM Tech explica o _porquê_ por trás das respostas. Dave Ebbelaar e Thu Vu mostram como usar raciocínio, agentes e encadeamento para ir mais longe—mas sempre com intenção.
+
+## Dica para líderes, devs e times
+
+Se você está começando com GenAI, não se preocupe em acertar tudo. Foque em **clareza, estrutura e iteração.**
+
+Use o MASTER no próximo:
+
+- Ticket de Jira
+- Rascunho de review de performance
+- Documento estratégico
+- Prompt de análise de dados
+- E-mail para o time
+
+E lembre-se: escrever prompts é uma habilidade. Fica melhor com prática—e fica _mais poderosa_ quando você trata a IA como colega de equipe.
+
+Mais em breve.


### PR DESCRIPTION
Technical details:
- Added bilingual Hugo posts for 2024-07-28 with identical filenames for i18n support
- English version: content/en/posts/2024-07-28-prompt-engineering-master-technique.md
- Portuguese version: content/pt/posts/2024-07-28-prompt-engineering-master-technique.md
- Comprehensive MASTER framework explanation (Markdown, Act, Specific, Threads, Examples, Regenerate)
- Practical user story creation example replacing generic marketing content
- Hugo frontmatter with categories (AI, Productivity, Engineering Management)
- Relevant tags for engineering audience: prompt-engineering, ai-literacy, master-technique

Content improvements:
Replaced travel marketing example with engineering-focused user story creation example that includes:
- Product manager role assignment with agile expertise
- Complete user story structure following "As a... I want... So that..." format
- Detailed acceptance criteria with technical specifications
- Real-world development context (notification systems, team collaboration)

Why this matters:
Engineering managers and development teams need practical examples that directly apply to their daily work. The user story example demonstrates MASTER technique application to common agile practices, making the content immediately actionable for software development workflows, sprint planning, and backlog management.

Hugo integration verified with proper URL generation and multilingual linking functionality.