### PR TITLE
feat(blog): add Socratic prompting posts for thinking better with AI

### DIFF
--- a/content/en/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
+++ b/content/en/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
@@ -1,0 +1,85 @@
+---
+title: "Using AI to Think Better (Not Just Faster)"
+categories:
+  - AI
+  - Productivity
+  - Critical Thinking
+date: 2024-09-05
+tags:
+  - socratic-prompting
+  - critical-thinking
+  - ai-collaboration
+  - cognitive-patterns
+  - thinking-frameworks
+  - genai
+description: "Discover how to transform AI from a fast answer machine into a thinking partner using Socratic prompting to improve your reasoning and decision-making process."
+subtitle: "Stop outsourcing your thinking - learn to use AI as a sparring partner that makes you think better, not just faster, through disciplined questioning."
+---
+
+# Using AI to Think Better (Not Just Faster)
+
+## Stop outsourcing your thinking
+
+Most people still treat AI like a turbocharged Google. You give it a question. It gives you an answer. Maybe it's right. Maybe it's helpful. Maybe it saves you a few minutes.
+
+But that's not the point.
+
+This month, I started leaning into a very different use case: **using AI to make me think better—not just faster.**
+
+## The shift: From assistant to sparring partner
+
+We often assume AI's biggest benefit is speed: writing emails faster, summarizing notes instantly, or brainstorming ideas on demand. That's useful. But what if AI could help you become a better thinker?
+
+That's where **Socratic prompting** comes in.
+
+Instead of asking ChatGPT to give you answers, you ask it to ask _you_ questions—one at a time, without ever giving an answer.
+
+Here's a prompt I now keep as a shortcut on macOS:
+
+> I want you to only ask me questions now, so that you're forcing me to actually think. Do not give me answers. Just pull the ideas out of me. Ask one question at a time and wait for my response.
+
+This turns your interaction from passive to active. You're no longer consuming. You're reasoning. You're reflecting. You're leading the conversation.
+
+## A real example: Designing a system architecture
+
+Let's say you're building a new backend service. Normally you might ask:
+
+> "Design a scalable service architecture for real-time asset tracking."
+
+And GPT would happily generate something, maybe too generic or too complex.
+
+But with the ask-only prompt, the conversation changes:
+
+- What are you trying to achieve with this?
+- What trade-offs are you considering?
+- Why do you think this approach works?
+- What assumptions are you making?
+
+This line of questioning _sharpens your thinking_. It doesn't hand you a solution—it helps you uncover your own.
+
+## Why this pattern matters
+
+The "ask-only" prompt isn't a hack. It's a **cognitive pattern**. One that mirrors the **Socratic method**, a form of disciplined questioning used to draw out ideas and challenge assumptions.
+
+By forcing you to explain, justify, and reflect, you build a deeper mental model of the problem. You go from "What should I do?" to "Why do I believe this is the right step?"
+
+In a world full of automation, this is a rare way to **slow down to go deeper**—and paradoxically, get to better answers faster.
+
+## Make it part of your workflow
+
+If you're on macOS, here's a simple setup to make this accessible anywhere:
+
+1. Open **System Settings** → **Keyboard** → **Text Replacements**
+2. Create a new shortcut:
+   - Replace: `:critical:`
+   - With:
+   ```
+   I want you to only ask me questions now, so that you're forcing me to think. Don't give me answers. Ask one question at a time.
+   ```
+3. Done! Now just type `:critical:` in ChatGPT, Notes, or anywhere else, and start sparring.
+
+## Final thought
+
+The best use of AI isn't passive. It's participatory. The real benefit isn't what AI gives you—it's what it pulls _out_ of you.
+
+This month's reminder: you don't need better answers. You need better questions. Let AI help you find them.

--- a/content/pt/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
+++ b/content/pt/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
@@ -1,0 +1,85 @@
+---
+title: "Usando IA para Pensar Melhor (Não Apenas Mais Rápido)"
+categories:
+  - AI
+  - Productivity
+  - Critical Thinking
+date: 2024-09-05
+tags:
+  - prompt-socratico
+  - pensamento-critico
+  - colaboracao-ia
+  - padroes-cognitivos
+  - frameworks-pensamento
+  - genai
+description: "Descubra como transformar a IA de uma máquina de respostas rápidas em um parceiro de pensamento usando prompts socráticos para melhorar seu raciocínio e tomada de decisão."
+subtitle: "Pare de terceirizar seu pensamento - aprenda a usar IA como parceiro de debate que te faz pensar melhor, não só mais rápido, através de questionamentos estruturados."
+---
+
+# Usando IA para Pensar Melhor (Não Apenas Mais Rápido)
+
+## Pare de terceirizar seu pensamento
+
+A maioria das pessoas ainda trata a IA como um Google turbinado. Você faz uma pergunta. Ela dá uma resposta. Às vezes está certa. Às vezes ajuda. Às vezes economiza tempo.
+
+Mas esse não é o ponto.
+
+Neste mês, comecei a experimentar um uso bem diferente: **usar a IA para pensar melhor—não só mais rápido.**
+
+## A mudança: De assistente para parceiro de debate
+
+Costumamos imaginar que a maior vantagem da IA é a velocidade: escrever e-mails rapidamente, resumir textos automaticamente ou gerar ideias em segundos. Isso é útil. Mas e se a IA pudesse ajudar você a se tornar um pensador melhor?
+
+É aí que entra o conceito de **prompt socrático**.
+
+Em vez de pedir respostas ao ChatGPT, você pede que ele te faça _perguntas_—uma de cada vez, sem nunca dar a resposta.
+
+Aqui está o prompt que agora uso como atalho no macOS:
+
+> Quero que você apenas me faça perguntas agora, para me forçar a pensar. Não me dê respostas. Apenas puxe as ideias de mim. Faça uma pergunta por vez e espere minha resposta.
+
+Essa abordagem muda tudo: você deixa de ser passivo e passa a refletir, justificar e liderar a conversa.
+
+## Um exemplo prático: Arquitetando um sistema
+
+Imagine que você está criando um novo serviço backend. Em geral, você pediria:
+
+> "Desenhe uma arquitetura escalável para rastreamento de ativos em tempo real."
+
+E o GPT geraria algo—talvez genérico, talvez complexo demais.
+
+Com o prompt socrático, a conversa muda:
+
+- O que você está tentando alcançar com isso?
+- Quais trade-offs você está considerando?
+- Por que acha que essa abordagem funciona?
+- Que suposições você está fazendo?
+
+Esse tipo de interação _afina seu raciocínio_. Não entrega a resposta—te ajuda a construí-la.
+
+## Por que esse padrão importa
+
+O "prompt socrático" não é um truque. É um **padrão cognitivo**. Ele espelha o **método socrático**, uma forma de questionamento estruturado usada para estimular reflexão e desafiar suposições.
+
+Ao explicar, justificar e explorar suas ideias, você cria um modelo mental mais robusto. Em vez de perguntar "o que devo fazer?", você se pergunta "por que acredito que essa é a melhor escolha?"
+
+Num mundo de automatização crescente, essa é uma forma rara de **desacelerar para aprofundar**—e paradoxalmente, chegar a melhores respostas mais rápido.
+
+## Incorpore no seu dia a dia
+
+Se você usa macOS, aqui está como criar esse atalho:
+
+1. Vá em **Ajustes do Sistema** → **Teclado** → **Substituições de Texto**
+2. Crie um novo atalho:
+   - Substituir: `:critical:`
+   - Por:
+   ```
+   Quero que você apenas me faça perguntas agora, para me forçar a pensar. Não me dê respostas. Faça uma pergunta por vez.
+   ```
+3. Pronto! Agora é só digitar `:critical:` no ChatGPT, Notas ou onde quiser, e começar a refletir.
+
+## Conclusão
+
+O melhor uso da IA não é passivo. É participativo. O verdadeiro valor não está no que a IA entrega—mas no que ela ajuda você a extrair de si mesmo.
+
+Lembrete do mês: você não precisa de melhores respostas. Precisa de melhores perguntas. Deixe a IA te ajudar a encontrá-las.


### PR DESCRIPTION
Technical details:
- Added bilingual Hugo posts for 2024-09-05 with identical filenames for i18n support
- English version: content/en/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
- Portuguese version: content/pt/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
- Comprehensive guide to Socratic prompting and cognitive enhancement through AI
- Practical system architecture example demonstrating questioning vs answer-seeking
- Hugo frontmatter with categories (AI, Productivity, Critical Thinking) and specialized tags
- macOS Text Replacements integration for :critical: shortcut implementation

Content focus:
This article introduces a paradigm shift from using AI as a fast answer machine to using it as a thinking partner. Demonstrates how Socratic prompting transforms passive AI consumption into active reasoning by having AI ask questions instead of providing answers. Shows practical application through system design scenarios where questioning sharpens technical decision-making.

Cognitive framework:
- Transforms interaction from passive to participatory
- Builds deeper mental models through self-reflection and justification
- Mirrors classical Socratic method of disciplined questioning
- Moves from "what should I do?" to "why do I believe this is right?"
- Emphasizes slowing down to think deeper for paradoxically better results

Why this matters:
Engineering managers need to enhance their thinking quality, not just speed. This approach helps build stronger reasoning capabilities while using AI as a cognitive enhancement tool rather than a replacement for critical thinking. Complements the existing AI series by moving beyond productivity to actual intellectual development.

Hugo integration verified with proper URL generation and multilingual linking functionality.