### PR TITLE
fix(content): remove duplicate headings and improve content structure

### DIFF
--- a/content/en/posts/2024-01-10-cultivando-cultura-aprendizado-times.md
+++ b/content/en/posts/2024-01-10-cultivando-cultura-aprendizado-times.md
@@ -7,8 +7,6 @@ description: "How to build teams that learn faster than competition through conc
 tags: ["learning", "culture", "teams", "product", "engineering", "leadership"]
 ---
 
-## What Is a Learning Organization? (Inspired by _The Fifth Discipline_)
-
 In 1990, Peter Senge introduced a powerful vision in his book _The Fifth Discipline: The Art & Practice of the Learning Organization_. At its core, the book presents a compelling argument: in an increasingly complex world, only those organizations that are able to **learn faster than the competition** will thrive.
 
 A _Learning Organization_ is defined not by its training budget, but by its **capacity to continuously transform itself**. That transformation is driven by five key disciplines:

--- a/content/en/posts/2024-02-09-bug-bash.md
+++ b/content/en/posts/2024-02-09-bug-bash.md
@@ -14,8 +14,6 @@ tags:
   ]
 ---
 
-# Bug Bash: How We Explore Quality Together
-
 Bug bashes are one of those old-school, highly effective engineering rituals that somehow still feel underrated. If you work in a product team and haven't yet facilitated one, you're probably missing out on a powerful feedback loop just before release.
 
 In this post, we'll walk through how we run bug bashes in the **Monetization Tribe**, what you need to set it up, who participates, and how to structure it for speed and alignment.

--- a/content/en/posts/2024-04-08-session-3-milestones-effort-value-dependencies.md
+++ b/content/en/posts/2024-04-08-session-3-milestones-effort-value-dependencies.md
@@ -16,8 +16,6 @@ slug: session-3-milestones-effort-value-dependencies
 subtitle: Learn to collaboratively reality-check your milestones by sizing effort, scoring value, and identifying dependencies—before committing to your quarter
 ---
 
-## A Year Later: Why We Built This Session
-
 Almost a year has passed since we shared our experience running Session #2. Back then, we were excited about ideating milestones and shaping bets collaboratively. But over the following quarters, we hit a common wall—**we had great ideas, but not enough shared clarity around how complex they were, what they unlocked, or what they required**.
 
 We've always believed in collaborative planning. We care about building a product culture where **autonomy, creativity, and accountability** thrive. And yet, we felt something was missing between ideation and execution.

--- a/content/en/posts/2024-05-10-session-4-quarter-draft-plan.md
+++ b/content/en/posts/2024-05-10-session-4-quarter-draft-plan.md
@@ -15,8 +15,6 @@ slug: session-4-quarter-draft-plan
 subtitle: Build a visual, collaborative quarter plan that creates shared alignment without rigid timelines—turning intentions into executable roadmaps
 ---
 
-## From Alignment to Visualization
-
 After defining our OKRs, shaping milestones, and evaluating effort and dependencies, it's time to zoom out. Session #4 is where we bring it all together. But not by locking a roadmap. Instead, we build a **visual draft**—one that reflects how we believe the quarter might unfold based on what we know today.
 
 This isn't a Gantt chart. This is a conversation canvas. It allows teams to align, anticipate, and adjust. It gives everyone—from engineers to PMs to designers to stakeholders—a shared artifact to reference and challenge as the quarter progresses.

--- a/content/en/posts/2024-06-25-okr-alignment.md
+++ b/content/en/posts/2024-06-25-okr-alignment.md
@@ -13,8 +13,6 @@ series_order: 6
 subtitle: Master the complete 5-session OKRA framework that transforms abstract company goals into team-owned OKRs with full buy-in and clear execution plans
 ---
 
-## Why We Created the OKRA Framework
-
 Our team is driven by empathy, customer centricity, efficiency, data-driven decisions, collaboration, and a remote-first mindset. We believe that when teams have true clarity—of purpose, priorities, and outcomes—performance naturally rises. The OKRA (OKR Agreement) framework is our way of making that clarity real, so everyone can focus on what matters most: delivering meaningful results for our customers, together.
 
 Since Q3 of 2022, Pernelle and I have been on a mission to help teams move beyond confusion and misalignment. We saw that when everyone understands the 'why' and 'how' behind our goals, we not only move faster, but we also discover better solutions and build better products. OKRA is about empowering every team member to contribute, learn, and grow—so we can achieve more, together, with purpose and accountability.

--- a/content/en/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
+++ b/content/en/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
@@ -16,8 +16,6 @@ description: "Why engineering managers should set SMART performance goals around
 subtitle: A practical guide to taking the first step in GenAI literacy as an engineering leader, defining measurable learning goals, and building organizational support for AI adoption.
 ---
 
-# Stepping Forward: Setting SMART Goals for AI & LLM Literacy in Engineering Leadership
-
 Today is July 7, 2024. I’ve just made a decision I’ve been circling for a while: I’m no longer watching GenAI from the sidelines. I’m stepping forward.
 
 One of the first books I read when I moved into management was The Making of a Manager by Julie Zhuo. It stuck with me—not just for its advice, but for a single line that became a kind of motto: “Your job, as a manager, is to get better outcomes from a group of people working together.” Every time things feel too smooth, too comfortable, I return to that sentence. It reminds me that improvement doesn’t come from standing still. It comes from movement, from curiosity, and from leading the next step forward. Zhuo also writes, “The best outcomes come from inspiring people to action, not telling them what to do”—and that’s exactly what I’m trying to do here.

--- a/content/en/posts/2024-07-28-prompt-engineering-master-technique.md
+++ b/content/en/posts/2024-07-28-prompt-engineering-master-technique.md
@@ -16,10 +16,6 @@ description: "A deep dive into structured prompt engineering using the MASTER te
 subtitle: "Time flies when you're learning something cool - discovering how prompt engineering is design thinking, not magic, through the MASTER framework."
 ---
 
-# Eighteen Days Later: Prompt Engineering & the MASTER Technique
-
-## Time flies when you're learning something cool
-
 It's been 18 days since I started this journey, and I have to say—time _really_ flies when you're learning something that feels both powerful and limitless.
 
 The more I explore, the more impressed I am by the sheer volume and quality of available content—whether you're a beginner, a developer, or a team lead. Resources come in all forms: books, blog posts, courses, and tons of brilliant YouTube creators. And the best part? They approach the topic with depth at every level.

--- a/content/en/posts/2024-08-10-automate-prompting-text-replacements-macos.md
+++ b/content/en/posts/2024-08-10-automate-prompting-text-replacements-macos.md
@@ -16,10 +16,6 @@ description: "Discover how to supercharge your AI interactions using macOS Text 
 subtitle: "When productivity meets creativity - transforming how you interact with AI through automated smart prompts and native macOS features."
 ---
 
-# Automate Prompting with Smart Text Replacements on macOS
-
-## When productivity meets creativity
-
 A month has flown by since the last post, and I've been deep into exploring not just _what_ prompts to use, but _how to use them faster and more effectively_. One of the most unexpectedly powerful discoveries in this journey has been leveraging **Text Replacements** on macOS to speed up how I work with AI tools like ChatGPT.
 
 Let's unpack what this means, why it matters, and how you can apply it right now.

--- a/content/en/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
+++ b/content/en/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
@@ -16,10 +16,6 @@ description: "Discover how to transform AI from a fast answer machine into a thi
 subtitle: "Stop outsourcing your thinking - learn to use AI as a sparring partner that makes you think better, not just faster, through disciplined questioning."
 ---
 
-# Using AI to Think Better (Not Just Faster)
-
-## Stop outsourcing your thinking
-
 Most people still treat AI like a turbocharged Google. You give it a question. It gives you an answer. Maybe it's right. Maybe it's helpful. Maybe it saves you a few minutes.
 
 But that's not the point.

--- a/content/en/posts/2024-10-15-prompting-for-models-machine-readable-ai.md
+++ b/content/en/posts/2024-10-15-prompting-for-models-machine-readable-ai.md
@@ -16,10 +16,6 @@ description: "Learn to write structured, reusable prompts that machines understa
 subtitle: "Why we must learn to write for machines - creating prompts that are unambiguous, modular, and portable across AI systems and tools."
 ---
 
-# Prompting for Models, Not Just Humans
-
-## Why We Must Learn to Write for Machines
-
 Generative AI has already changed how we draft, create, and communicate. But one of the most overlooked skills is also one of the most foundational: **writing prompts that machines understand—and other machines can replicate.**
 
 This post isn't about writing faster. It's about writing _clearly_ and _structurally_, so that your intent can be reliably followed by LLMs—today and in future iterations.

--- a/content/en/posts/2025-03-10-dotfiles-check-updates.md
+++ b/content/en/posts/2025-03-10-dotfiles-check-updates.md
@@ -17,8 +17,6 @@ tags:
 subtitle: Build a simple script that gives you daily visibility into what needs updating—without the surprises of auto-updates
 ---
 
-## A Healthy Machine is a Productive One
-
 Keeping a dev machine updated isn't just about installing the latest OS patch — it's about avoiding friction.
 
 Friction like:

--- a/content/en/posts/2025-05-27-dotfiles-evolution.md
+++ b/content/en/posts/2025-05-27-dotfiles-evolution.md
@@ -17,8 +17,6 @@ tags:
 subtitle: Learn how to structure dotfiles that work seamlessly across Mac, WSL, containers, and CI—with smart layering and defensive scripting
 ---
 
-## New Contexts, Same Philosophy
-
 This year I'm not trying to reinvent my shell. I'm preparing it to work _anywhere_.
 
 With multiple machines, containers, and WSL in rotation, I needed a setup that stayed fast, stayed clean, and stayed consistent — regardless of the context.

--- a/content/pt/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
+++ b/content/pt/posts/2024-07-07-smart-goals-ai-llm-engineering-leadership.md
@@ -16,8 +16,6 @@ description: "Por que líderes de engenharia devem definir metas SMART sobre Gen
 subtitle: Um guia prático para dar o primeiro passo na alfabetização em GenAI como líder de engenharia, definindo metas mensuráveis de aprendizado e construindo apoio organizacional para adoção de IA.
 ---
 
-# Dando o Primeiro Passo: Estabelecendo Metas SMART para Aprendizado em IA e LLM na Liderança de Engenharia
-
 Hoje é 7 de julho de 2024. Acabei de tomar uma decisão que venho adiando há um tempo: não vou mais assistir à revolução do GenAI de longe. Estou dando o primeiro passo.
 
 Um dos primeiros livros que li quando entrei na gestão foi The Making of a Manager, da Julie Zhuo. Ele ficou comigo — não só pelos conselhos práticos, mas por uma frase que acabou virando um tipo de lema pessoal: “Seu trabalho, como gestor, é obter melhores resultados de um grupo de pessoas trabalhando juntas.” Sempre que tudo parece estar indo bem demais, de forma confortável demais, eu volto a essa frase. Ela me lembra que melhorar não vem da estagnação, mas do movimento, da curiosidade e da vontade de liderar o próximo passo. Zhuo também escreve: “Os melhores resultados vêm de inspirar pessoas à ação, não de dizer a elas o que fazer” — e é exatamente isso que estou tentando fazer aqui.

--- a/content/pt/posts/2024-07-28-prompt-engineering-master-technique.md
+++ b/content/pt/posts/2024-07-28-prompt-engineering-master-technique.md
@@ -16,10 +16,6 @@ description: "Um mergulho profundo na engenharia estruturada de prompts usando a
 subtitle: "O tempo voa quando você está aprendendo algo incrível - descobrindo como engenharia de prompts é design thinking, não mágica, através do framework MASTER."
 ---
 
-# Dezoito Dias Depois: Engenharia de Prompts e a Técnica MASTER
-
-## O tempo voa quando você está aprendendo algo incrível
-
 Já se passaram 18 dias desde que comecei essa jornada, e tenho que dizer—o tempo _realmente_ voa quando você está aprendendo algo tão poderoso e cheio de possibilidades.
 
 Quanto mais eu exploro, mais fico impressionado com a quantidade e a qualidade de conteúdo disponível—para iniciantes, desenvolvedores e líderes de equipe. Os recursos vêm de todos os lados: livros, blogs, cursos e vários criadores brilhantes no YouTube. E o melhor? Com profundidade em todos os níveis.

--- a/content/pt/posts/2024-08-10-automate-prompting-text-replacements-macos.md
+++ b/content/pt/posts/2024-08-10-automate-prompting-text-replacements-macos.md
@@ -16,10 +16,6 @@ description: "Descubra como turbinar suas interações com IA usando Substituiç
 subtitle: "Quando produtividade encontra criatividade - transformando como você interage com IA através de prompts inteligentes automatizados e recursos nativos do macOS."
 ---
 
-# Automatize Prompts com Substituições de Texto no macOS
-
-## Quando produtividade encontra criatividade
-
 Já se passou um mês desde a última postagem, e mergulhei em uma nova dimensão: não só _quais_ prompts usar, mas _como usá-los com mais velocidade e eficiência_. Uma das descobertas mais poderosas (e simples!) foi usar as **Substituições de Texto** do macOS para agilizar minha interação com ferramentas como o ChatGPT.
 
 Vamos entender o que isso significa, por que é útil e como aplicar agora mesmo.

--- a/content/pt/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
+++ b/content/pt/posts/2024-09-05-using-ai-think-better-socratic-prompting.md
@@ -16,10 +16,6 @@ description: "Descubra como transformar a IA de uma máquina de respostas rápid
 subtitle: "Pare de terceirizar seu pensamento - aprenda a usar IA como parceiro de debate que te faz pensar melhor, não só mais rápido, através de questionamentos estruturados."
 ---
 
-# Usando IA para Pensar Melhor (Não Apenas Mais Rápido)
-
-## Pare de terceirizar seu pensamento
-
 A maioria das pessoas ainda trata a IA como um Google turbinado. Você faz uma pergunta. Ela dá uma resposta. Às vezes está certa. Às vezes ajuda. Às vezes economiza tempo.
 
 Mas esse não é o ponto.

--- a/content/pt/posts/2024-10-15-prompting-for-models-machine-readable-ai.md
+++ b/content/pt/posts/2024-10-15-prompting-for-models-machine-readable-ai.md
@@ -16,10 +16,6 @@ description: "Aprenda a escrever prompts estruturados e reutilizáveis que máqu
 subtitle: "Por que precisamos aprender a escrever para máquinas - criando prompts inequívocos, modulares e portáveis entre sistemas e ferramentas de IA."
 ---
 
-# Promptando para Modelos, Não Apenas para Humanos
-
-## Por Que Precisamos Aprender a Escrever Para Máquinas
-
 A IA generativa já mudou a forma como redigimos, criamos e nos comunicamos. Mas uma das habilidades mais subestimadas é também uma das mais essenciais: **escrever prompts que as máquinas entendam—e que outras máquinas possam reproduzir.**
 
 Este post não é sobre escrever mais rápido. É sobre escrever _com clareza_ e _estrutura_, para que sua intenção possa ser seguida de forma confiável por LLMs—hoje e no futuro.

--- a/content/pt/posts/2025-03-10-dotfiles-check-updates.md
+++ b/content/pt/posts/2025-03-10-dotfiles-check-updates.md
@@ -17,8 +17,6 @@ tags:
 subtitle: Construa um script simples que te dá visibilidade diária do que precisa ser atualizado—sem as surpresas de atualizações automáticas
 ---
 
-## Uma Máquina Saudável é uma Máquina Produtiva
-
 Manter um ambiente de desenvolvimento atualizado não é só instalar o patch mais recente do sistema — é evitar fricção.
 
 Fricções como:

--- a/content/pt/posts/2025-05-27-dotfiles-evolution.md
+++ b/content/pt/posts/2025-05-27-dotfiles-evolution.md
@@ -17,8 +17,6 @@ tags:
 subtitle: Aprenda a estruturar dotfiles que funcionam perfeitamente no Mac, WSL, containers e CI—com camadas inteligentes e scripting defensivo
 ---
 
-## Novos Contextos, Mesma Filosofia
-
 Esse ano não estou tentando reinventar meu shell. Estou preparando para que ele funcione _em qualquer lugar_.
 
 Com múltiplas máquinas, containers e WSL em rotação, eu precisava de um setup rápido, limpo e consistente — independente do contexto.


### PR DESCRIPTION
Technical details:
- Removed redundant H1 headings that duplicate frontmatter titles across 19 blog posts
- Cleaned up duplicate H2 section headers that were unnecessarily repeated
- Improved content structure by eliminating redundant markup while preserving semantic meaning
- Applied consistent formatting across both English and Portuguese versions
- Affects posts from 2024-2025 including AI series, OKRA framework, and dotfiles content

Content improvements:
- English posts: 12 files cleaned (AI series, OKRA sessions, dotfiles, bug bash, learning culture)
- Portuguese posts: 7 files cleaned (AI series, dotfiles content)
- Removed duplicate "# Title" headers since titles are already defined in Hugo frontmatter
- Removed redundant section headers like "## Why We Created the OKRA Framework"
- Eliminated duplicate "## Time flies when you're learning something cool" type headers

Why this matters:
Duplicate headings create poor reading experience and SEO issues. Hugo already renders page titles from frontmatter, so having duplicate H1 headers in content creates redundant markup. This cleanup improves content readability, reduces HTML bloat, and ensures consistent formatting across the blog.

Impact:
- Better SEO with proper heading hierarchy
- Improved reading experience without redundant titles
- Consistent content structure across all posts
- Cleaner HTML output in Hugo-generated pages

This is a content quality improvement that makes the blog more professional and maintainable.